### PR TITLE
Remove needless quote and use function-item

### DIFF
--- a/consult-dir.el
+++ b/consult-dir.el
@@ -134,8 +134,8 @@ The options are
 3. Any user-defined function. This function should take no
 arguments and return a list of directories."
   :type '(radio
-          (const :tag "Project.el projects" 'consult-dir-project-dirs)
-          (const :tag "Projectile projects" 'consult-dir-projectile-dirs)
+          (function-item :tag "Project.el projects" consult-dir-project-dirs)
+          (function-item :tag "Projectile projects" consult-dir-projectile-dirs)
           (function :tag "User-defined function")))
 
 (defcustom consult-dir-sources


### PR DESCRIPTION
This fixes the following byte-compile warning.

```
consult-dir.el:125:12: Warning: defcustom for
    ‘consult-dir-project-list-function’ has syntactically odd type ‘'(radio
    (const :tag Project.el projects 'consult-dir-project-dirs) (const :tag
    Projectile projects 'consult-dir-projectile-dirs) (function :tag
    User-defined function))’
```