### PR TITLE
Do not open connections to remote hosts from recentf

### DIFF
--- a/consult-dir.el
+++ b/consult-dir.el
@@ -264,8 +264,11 @@ Entries that are also in the list of projects are removed."
          (proj-list-hash (consult-dir--project-list-make))
          (in-other-source-p (lambda (dir) (not (or (and proj-list-hash (gethash dir proj-list-hash))
                                               (member dir current-dirs)))))
-         (file-directory-safe (lambda (f) (or (and (file-directory-p f) (file-name-as-directory f))
-                                         (file-name-directory f)))))
+         (file-directory-safe (lambda (f) (or (and (if (file-remote-p f)
+                                                       (string-suffix-p "/" f)
+                                                     (file-directory-p f))
+                                                   (file-name-as-directory f))
+                                              (file-name-directory f)))))
     (thread-last recentf-list
       (mapcar file-directory-safe)
       (delete-dups)


### PR DESCRIPTION
`file-directory-p` opens a connection to each remote host found in `recentf-list`.
It may cause serious slow down, also password prompt may popup for sudo or password protected ssh hosts.

This PR uses `file-directory-p` only if an entry is local file or connection to remote host is already established.

What do you think?