### PR TITLE
consult-dir: Avoid opening connections for remote recent files

### DIFF
--- a/consult-dir.el
+++ b/consult-dir.el
@@ -286,11 +286,17 @@ Entries that are also in the list of projects are removed."
                                                        (string-suffix-p "/" f)
                                                      (file-directory-p f))
                                                    (file-name-as-directory f))
-                                              (file-name-directory f)))))
+                                              (file-name-directory f))))
+         ;; Trying to abbreviate remote recent file names can cause TRAMP to
+         ;; open connections, which can be slow and interrupt the user with
+         ;; prompts. See ‘tramp-file-name-handler’.
+         (abbreviate-local-file-name (lambda (f) (if (file-remote-p f)
+                                                     f
+                                                   (abbreviate-file-name f)))))
     (thread-last recentf-list
       (mapcar file-directory-safe)
       (delete-dups)
-      (mapcar #'abbreviate-file-name)
+      (mapcar abbreviate-local-file-name)
       (seq-filter in-other-source-p))))
 
 (defvar consult-dir--source-recentf


### PR DESCRIPTION
‘consult-dir’ abbreviates recent files for aesthetic purposes.

Users’ recent files can include remote files from an arbitrary number of hosts, particularly those who remove the ‘tramp-recentf-cleanup’ hook TRAMP installs by default to ‘tramp-cleanup-connection’. This is a reasonable usage pattern when connecting repeatedly to persistent “pet” remote hosts, where having recent file listings is a quick way to resume previous work.

TRAMP registers a handler for ‘abbreviate-file-name’ so it can abbreviate files correctly based on the remote environment. As a result, invoking ‘consult-dir’ can cause TRAMP to connect to every remote in ‘recentf-list’, a slow process that can interrupt the user with (e.g.) SSH_ASKPASS prompts.

The aesthetic improvements to remote file names are not worth the impact on performance and usability, so prevent abbreviating remote file names.

---

Hi Karthik,

Let me know what you think of this (and if it works on your machine). I followed suit on the thread-last/lambda style already used in this function. Thanks!

Liam

PS: I do have copyright assignment on file with the FSF under the name and email address used in the commit.