### PR TITLE
Bind `this-command` in `consult-dir-jump-file`

### DIFF
--- a/consult-dir.el
+++ b/consult-dir.el
@@ -375,13 +375,15 @@ Optional argument PROMPT is the prompt."
          (search (file-name-nondirectory mc)))
     (run-at-time
      0 nil
-     (lambda () (funcall consult-dir-jump-file-command dir
+     (lambda ()
+       (let ((this-command consult-dir-jump-file-command))
+         (funcall consult-dir-jump-file-command dir
                     (concat search
                             (unless (string-empty-p search)
                               (when-let ((style (alist-get consult-async-split-style
                                                            consult-async-split-styles-alist))
                                          (initial (plist-get style :initial)))
-                                (char-to-string initial)))))))
+                                (char-to-string initial))))))))
     (abort-recursive-edit)))
 
 ;;;###autoload


### PR DESCRIPTION
`consult-dir-jump-file` executes the target command (like `consult-find/fd`) via a timer, but it does not bind `this-command` to that target.

This causes an issue with `vertico-multiform`: since `this-command` is empty, Vertico cannot match the specific style configured for the actual jump command. For example, a custom display for `consult-find` will not be triggered.

- (consult-dir-jump-file): Bind `this-command` to
  `consult-dir-jump-file-command` within the deferred lambda. This ensures that
  the jump command (e.g., `consult-find`) identifies itself correctly, allowing
  completion UIs to adapt their styling accordingly.